### PR TITLE
Allow another Connection class in LoadBalancer

### DIFF
--- a/wikia/common/mw_database/build.json
+++ b/wikia/common/mw_database/build.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Mediawiki database connector",
     "install_requires": [
         "MySQL-python==1.2.5",

--- a/wikia/common/mw_database/connection.py
+++ b/wikia/common/mw_database/connection.py
@@ -247,7 +247,10 @@ class ConnectionQueryBuilder(SqlBuilderMixin):
         return self.connection._query(*args, **kwargs)
 
     def select_field(self, table, what, where):
-        return self.select(table, what, where).all_rows[0][0]
+        res = self.select(table, what, where)
+        if res.num_rows != 1:
+            raise ValueError("Query in select_field() returned {} rows instead of 1".format(res.num_rows))
+        return res.all_rows[0][0]
 
 
 class QueryResult(object):
@@ -258,6 +261,7 @@ class QueryResult(object):
         self.affected = affected
         self.description = description
         self.all_rows = all_rows
+        self.num_rows = len(all_rows)
 
     @property
     def to_dicts(self):

--- a/wikia/common/mw_database/connection.py
+++ b/wikia/common/mw_database/connection.py
@@ -185,17 +185,17 @@ class SqlBuilderMixin(object):
 
         return self.query(sql, args=sql_data)
 
-    def delete(self, table, where):
+    def delete(self, table, conds):
         """
         Execute DELETE statement
 
         :param table: Table name
-        :param where: Conditions
+        :param conds: Conditions
         :return:
         :rtype: QueryResult
         """
         sql_data = {}
-        sql = 'DELETE FROM {} WHERE {};'.format(table, self.where(where, sql_data))
+        sql = 'DELETE FROM {} WHERE {};'.format(table, self.where(conds, sql_data))
 
         return self.query(sql, args=sql_data)
 

--- a/wikia/common/mw_database/dbconfig.py
+++ b/wikia/common/mw_database/dbconfig.py
@@ -126,7 +126,7 @@ class DatabaseConfig(object):
                 dbname = host_override.get("dbname", dbname)
 
             service_override = self.mw_config["templateOverridesByService"].get(self.service_name, False)
-            if host_override is not False:
+            if service_override is not False:
                 username = service_override.get("user", username)
                 password = service_override.get("password", password)
 

--- a/wikia/common/mw_database/load_balancer.py
+++ b/wikia/common/mw_database/load_balancer.py
@@ -6,6 +6,8 @@ from .dbconfig import DatabaseConfig
 
 
 class LoadBalancer(object):
+    CONNECTION_CLASS = Connection
+
     def __init__(self, db_config_file=None, service_name=None, override_consul_dc=None):
         self.db_config_file = db_config_file
         self.db_config = DatabaseConfig(self.db_config_file, self._raw_connect, service_name)
@@ -18,7 +20,10 @@ class LoadBalancer(object):
         else:
             conn_details = self.db_config.get_external_connection_details(*args, **kwargs)
 
-        return Connection(self._raw_connect(conn_details), conn_details)
+        return self._create_connection(self._raw_connect(conn_details), conn_details)
+
+    def _create_connection(self, *args, **kwargs):
+        return self.CONNECTION_CLASS(*args, **kwargs)
 
     def _raw_connect(self, conn_details):
         if self.override_consul_dc is not None:


### PR DESCRIPTION
This will allow LoadBalancer subclasses to override the actual Connection class if needed.

Bonus: safety check for number of rows in select_field()

/cc @macbre 