### PR TITLE
SqlBuilderMixin: wrap column names in backticks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 venv/
 *.iml
 .idea
+*.swp
 
 coverage.xml
 env/

--- a/wikia/common/mw_database/build.json
+++ b/wikia/common/mw_database/build.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.5",
+    "version": "1.0.6",
     "description": "Mediawiki database connector",
     "install_requires": [
         "MySQL-python==1.2.5",

--- a/wikia/common/mw_database/query_builder.py
+++ b/wikia/common/mw_database/query_builder.py
@@ -42,7 +42,7 @@ class SqlBuilderMixin(object):
         values = []
         sql_data = {}
         for column, value in data.items():
-            columns.append(column)
+            columns.append('`{}`'.format(column))
             sql_value, is_value = self.add_value(value, sql_data, column)
             if not is_value:
                 raise ValueError('insert accepts only value literals')


### PR DESCRIPTION
We have tables that have `order` column, let's wrap column names in backticks when performing `INSERT` query.

```sql
INSERT IGNORE INTO vpt_asset(asset_id, updated_by, section, updated_at, program_id, data, order) VALUES (%(asset_id)s, %(updated_by)s, %(section)s, %(updated_at)s, %(program_id)s, %(data)s, %(order)s);
```

```sql
CREATE TABLE `vpt_asset` (
  `asset_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `program_id` int(10) unsigned NOT NULL,
  `section` varchar(255) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
  `order` tinyint(4) NOT NULL DEFAULT '1',
  `data` blob NOT NULL,
  `updated_by` int(10) unsigned NOT NULL,
  `updated_at` datetime NOT NULL,
  PRIMARY KEY (`asset_id`),
  UNIQUE KEY `asset` (`program_id`,`section`,`order`),
  KEY `program_id` (`program_id`,`section`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1;
```

@wladekb 