### PR TITLE
Fix select_fields helper

### DIFF
--- a/wikia/common/mw_database/build.json
+++ b/wikia/common/mw_database/build.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "Mediawiki database connector",
     "install_requires": [
         "MySQL-python==1.2.5",

--- a/wikia/common/mw_database/query_builder.py
+++ b/wikia/common/mw_database/query_builder.py
@@ -122,4 +122,4 @@ class SqlBuilderMixin(object):
         res = self.select(table, what, where)
         if res.num_rows != 1:
             raise ValueError("Query in select_field() returned {} rows instead of 1".format(res.num_rows))
-        return res.all_rows[0][0]
+        return res.rows[0][0]


### PR DESCRIPTION
```python
AttributeError: 'QueryResult' object has no attribute 'all_rows'
```

`all_rows` does not exist in `QueryResult`, use `rows` instead

@mixth-sense / @TK-999 