### PR TITLE
Kibana: use lb.service.sjc.consul instead of hardcoded host names

### DIFF
--- a/wikia/common/kibana/build.json
+++ b/wikia/common/kibana/build.json
@@ -1,8 +1,8 @@
 {
-    "version": "1.1.1",
+    "version": "1.2.0",
     "description": "Run queries against Kibana's Elasticsearch",
     "install_requires": [
-        "elasticsearch==1.2.0",
+        "elasticsearch==1.9.0",
         "python-dateutil==2.2"
     ]
 }

--- a/wikia/common/kibana/config.py
+++ b/wikia/common/kibana/config.py
@@ -1,7 +1,0 @@
-"""
-Config variables for kibana.py
-"""
-ELASTICSEARCH_HOSTS = [
-    'lb-s1',
-    'lb-s2'
-]

--- a/wikia/common/kibana/kibana.py
+++ b/wikia/common/kibana/kibana.py
@@ -11,8 +11,6 @@ from dateutil import tz
 
 from elasticsearch import Elasticsearch
 
-import config
-
 
 class KibanaError(Exception):
     pass
@@ -25,13 +23,20 @@ class Kibana(object):
     # seconds in 24h used to get the es index for yesterday
     DAY = 86400
 
+    ELASTICSEARCH_HOST = 'lb.service.sjc.consul'
+
     """ Interface for querying Kibana's storage """
-    def __init__(self, since=None, period=900):
+    def __init__(self, since=None, period=900, es_host=None):
         """
-         :arg since: UNIX timestamp data should be fetched since
-         :arg period: period (in seconds) before now() to be used when since is empty (defaults to last 15 minutes)
+        :type since int
+        :type period int
+        :type es_host str
+
+        :arg since: UNIX timestamp data should be fetched since
+        :arg period: period (in seconds) before now() to be used when since is empty (defaults to last 15 minutes)
+        :arg es_host: customize Elasticsearch host(s) that should be used for querying
         """
-        self._es = Elasticsearch(hosts=config.ELASTICSEARCH_HOSTS)
+        self._es = Elasticsearch(hosts=es_host if es_host else self.ELASTICSEARCH_HOST)
         self._logger = logging.getLogger('kibana')
 
         # if no timestamp provided, fallback to now() in UTC


### PR DESCRIPTION
```
>>> source.get_rows(match={"tags": 'edge-cache-requestmessage'}, limit=2)
DEBUG:kibana:Running {"filter": {"range": {"@timestamp": {"to": "2017-02-03T11:23:01.000Z", "from": "1970-01-01T03:25:46.000Z"}}}, "query": {"match": {"tags": "edge-cache-requestmessage"}}, "size": 2} query (limit set to 2)
DEBUG:urllib3.util.retry:Converted retries value: False -> Retry(total=False, connect=None, read=None, redirect=0)
DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): lb.service.sjc.consul
DEBUG:urllib3.connectionpool:http://lb.service.sjc.consul:9200 "GET /logstash-2017.02.02,logstash-2017.02.03/_search HTTP/1.1" 200 1996
INFO:elasticsearch:GET http://lb.service.sjc.consul:9200/logstash-2017.02.02,logstash-2017.02.03/_search [status:200 request:1.524s]
```