### PR TITLE
Use query-prod.es.service.sjc.consul as a new ES host

### DIFF
--- a/wikia/common/kibana/build.json
+++ b/wikia/common/kibana/build.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Run queries against Kibana's Elasticsearch",
     "install_requires": [
         "elasticsearch==1.9.0",

--- a/wikia/common/kibana/kibana.py
+++ b/wikia/common/kibana/kibana.py
@@ -23,7 +23,7 @@ class Kibana(object):
     # seconds in 24h used to get the es index for yesterday
     DAY = 86400
 
-    ELASTICSEARCH_HOST = 'lb.service.sjc.consul'
+    ELASTICSEARCH_HOST = 'query-prod.es.service.sjc.consul'
 
     """ Interface for querying Kibana's storage """
     def __init__(self, since=None, period=900, es_host=None, read_timeout=10):


### PR DESCRIPTION
```
$ curl 'query-prod.es.service.sjc.consul:9200'
{
  "status" : 200,
  "name" : "datalog-s3-1",
  "cluster_name" : "default-multiple",
  "version" : {
    "number" : "1.7.5",
    "build_hash" : "00f95f4ffca6de89d68b7ccaf80d148f1f70e4d4",
    "build_timestamp" : "2016-02-02T09:55:30Z",
    "build_snapshot" : false,
    "lucene_version" : "4.10.4"
  },
  "tagline" : "You Know, for Search"
}
```