### PR TITLE
wikia.common.kibana - use ES Scroll API

### DIFF
--- a/examples/kibana.py
+++ b/examples/kibana.py
@@ -12,6 +12,9 @@ from wikia.common.kibana import Kibana
 logging.basicConfig(level=logging.INFO)
 source = Kibana(period=3600)
 
+rows = source.get_rows(match={"tags": 'edge-cache-requestmessage'}, limit=5000)  # fetch many rows
+print(len(rows))
+
 rows = source.get_rows(match={"tags": 'edge-cache-requestmessage'})
 print json.dumps(rows, indent=True)
 

--- a/wikia/common/kibana/build.json
+++ b/wikia/common/kibana/build.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Run queries against Kibana's Elasticsearch 5",
     "install_requires": [
         "elasticsearch>=5.0.0,<6.0.0",


### PR DESCRIPTION
This allows us to fetch more than 10k results and prevent "search_phase_execution_exception":

```
Result window is too large, from + size must be less than or equal to: [10000] but was [500000]. See the scroll api for a more efficient way to request large data sets.
```

See https://www.elastic.co/guide/en/elasticsearch/guide/current/scroll.html