### PR TITLE
ES 6.x fixes

### DIFF
--- a/wikia/common/kibana/kibana.py
+++ b/wikia/common/kibana/kibana.py
@@ -139,7 +139,7 @@ class Kibana(object):
                 'script': {
                     'script': {
                         'lang': 'painless',
-                        'inline': "Math.abs(doc['_uid'].value.hashCode()) % 100 < params.sampling",
+                        'source': "Math.abs(doc['_id'].value.hashCode()) % 100 < params.sampling",
                         'params': {
                             'sampling': sampling
                         }


### PR DESCRIPTION
ES reports deprecated fields in query, to avoid surprises in future lets move to the new syntax:
```
Warning: 299 Elasticsearch-6.1.0-c0c1ba0 "Deprecated field [inline] used, expected [source] instead" "Wed, 20 Dec 2017 00:53:13 GMT".
Warning: 299 Elasticsearch-6.1.0-c0c1ba0 "Fielddata access on the _uid field is deprecated, use _id instead" "Wed, 20 Dec 2017 00:53:13 GMT".
```