### PR TITLE
Bumping versions - use ES 6.1

### DIFF
--- a/wikia/common/kibana/build.json
+++ b/wikia/common/kibana/build.json
@@ -1,8 +1,8 @@
 {
-    "version": "2.2.2",
+    "version": "2.2.3",
     "description": "Run queries against Kibana's Elasticsearch 5",
     "install_requires": [
-        "elasticsearch>=5.0.0,<6.0.0",
+        "elasticsearch>=6.0.0,<7.0.0",
         "python-dateutil==2.2"
     ]
 }

--- a/wikia/common/kibana/build.json
+++ b/wikia/common/kibana/build.json
@@ -1,6 +1,6 @@
 {
     "version": "2.2.3",
-    "description": "Run queries against Kibana's Elasticsearch 5",
+    "description": "Run queries against Kibana's Elasticsearch 6",
     "install_requires": [
         "elasticsearch>=6.0.0,<7.0.0",
         "python-dateutil==2.2"


### PR DESCRIPTION
-  Use elasticsearch module compatible with es6
- bump kibana module version to release https://github.com/Wikia/python-commons/pull/30