### PR TITLE
logger: python3 fix

### DIFF
--- a/wikia/common/logger/__init__.py
+++ b/wikia/common/logger/__init__.py
@@ -10,4 +10,4 @@ import pkg_resources
 
 from .logger import Logger, LogFormatter, LogRecord
 
-__version__ = json.loads(pkg_resources.resource_string(__name__, 'build.json'))['version']
+__version__ = json.loads(pkg_resources.resource_string(__name__, 'build.json').decode('utf-8'))['version']

--- a/wikia/common/logger/build.json
+++ b/wikia/common/logger/build.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "Common logging classes for centralized logging at Wikia",
     "install_requires": [
         "python-json-logger==0.1.8"


### PR DESCRIPTION
In python3 `json.loads` requires a string, otherwise it throws `TypeError: the JSON object must be str, not 'bytes'` so you cannot import the module
