### PR TITLE
DE-XXXX | Remove deleted star-args rule

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -11,7 +11,7 @@ persistent = no
 
 [MESSAGES CONTROL]
 # Messages to disable
-disable = star-args,too-few-public-methods,too-many-public-methods,too-many-arguments,abstract-method
+disable = too-few-public-methods,too-many-public-methods,too-many-arguments,abstract-method
 
 [REPORTS]
 # Colorize output


### PR DESCRIPTION
star-args was removed in newer Pylint releases:

```
Remove three warnings: star-args, abstract-class-little-used, abstract-class-not-used. These warnings don't add any real value and they don't imply errors or problems in the code.
```
https://pylint.pycqa.org/en/latest/whatsnew/1/1.4.html#what-s-new-in-pylint-1-4-3.